### PR TITLE
Fixes in webserver setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Rather than executing start.sh, use Kubernetes.yml to describe pod setup.
 3. Add a superuser to paperless-ngx with:
 
 ```bash
-$ podman exec -it paperless-paperless-webserver python manage.py createsuperuser
+$ podman exec -it paperless-webserver python manage.py migrate
+$ podman exec -it paperless-webserver python manage.py createsuperuser
 ```
 
 Didn't support other part of the config yet (SFTP / postgres) since I am just discoverint Paperless-ngx.


### PR DESCRIPTION
While following the instructions I stumbled upon two problems:

* The name of the container is just `paperless-webserver` instead of `paperless-paperless-webserver`.

* To create the superuser, django database migrations have to be applied first, otherwise an error is issued about the user table not existing.